### PR TITLE
Update Activity Shared Item Action Type

### DIFF
--- a/app/models/social_networking/shareable.rb
+++ b/app/models/social_networking/shareable.rb
@@ -1,0 +1,12 @@
+module SocialNetworking
+  # Allows for shareable items to be passed in to evaluate properties
+  class Shareable
+    def initialize(item = nil)
+      @item = item
+    end
+
+    def action
+      @item.try(:action) || "Shared"
+    end
+  end
+end

--- a/app/models/social_networking/shared_item.rb
+++ b/app/models/social_networking/shared_item.rb
@@ -1,14 +1,20 @@
 module SocialNetworking
   # An item that a Participant has shared.
   class SharedItem < ActiveRecord::Base
-    before_save :default_creator
+    before_save :default_creator, :set_action_type
 
     belongs_to :item, polymorphic: true
     has_many :comments, as: "item"
     has_many :likes, as: "item"
 
+    private
+
     def default_creator
       self.participant_id = item.participant_id
+    end
+
+    def set_action_type
+      self.action_type = Shareable.new(item).action
     end
   end
 end

--- a/spec/dummy/app/models/activity.rb
+++ b/spec/dummy/app/models/activity.rb
@@ -1,0 +1,2 @@
+class Activity < ActiveRecord::Base
+end

--- a/spec/dummy/db/migrate/20150309210518_create_activities.rb
+++ b/spec/dummy/db/migrate/20150309210518_create_activities.rb
@@ -1,0 +1,8 @@
+class CreateActivities < ActiveRecord::Migration
+  def change
+    create_table :activities do |t|
+      t.integer :participant_id, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,10 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141223203721) do
+ActiveRecord::Schema.define(version: 20150309210518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activities", force: :cascade do |t|
+    t.integer  "participant_id", null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
 
   create_table "arms", force: :cascade do |t|
     t.string  "title",     default: "",    null: false

--- a/spec/models/social_networking/shareable_spec.rb
+++ b/spec/models/social_networking/shareable_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+module SocialNetworking
+  describe Shareable do
+    context "when intialized without an instance" do
+      subject(:shareable) { Shareable.new }
+
+      describe "#action" do
+        it "should display's the default action" do
+          expect(shareable.action).to eq "Shared"
+        end
+      end
+    end
+
+    context "when intialized with an instance" do
+      let(:action_text) { "I have an action" }
+      let(:activity) { "ActivityKlass" }
+      subject(:shareable) { Shareable.new(activity) }
+
+      describe "#action" do
+        it "should display's an activities status label" do
+          allow(activity).to receive(:action) { action_text }
+
+          expect(shareable.action).to eq action_text
+        end
+      end
+    end
+  end
+end

--- a/spec/models/social_networking/shared_item_spec.rb
+++ b/spec/models/social_networking/shared_item_spec.rb
@@ -9,5 +9,18 @@ module SocialNetworking
       shared_item = SharedItem.create(item: goal, action_type: "action_type")
       expect(shared_item.participant_id).to eq(700_141_617)
     end
+
+    describe "when saving" do
+      let(:activity) do
+        Activity.create!(participant_id: participants(:participant1).id)
+      end
+
+      it "the action type is set on a shared item" do
+        allow(activity).to receive(:action).and_return("Monitored")
+        shared_item = SharedItem.create!(item: activity)
+
+        expect(shared_item.action_type).to eq("Monitored")
+      end
+    end
   end
 end


### PR DESCRIPTION
Update Activity Shared Item Action Type

* Add callback that sets the the action type of an activity
  to be the status type of an activity.
* Update schema to have an activity model.
* Add spec to test model callback.

[#88917838]