### PR TITLE
Remove Error from Home Controller

### DIFF
--- a/app/assets/javascripts/social_networking/controllers/home-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/home-controller.js
@@ -178,7 +178,7 @@
 
   HomeCtrl.prototype.profileIconSrcFor = function(item) {
     for (var i = 0; i < this._memberProfiles.length; i += 1) {
-      if (this._memberProfiles[i].participantId === item.participantId) {
+      if (item && (this._memberProfiles[i].participantId === item.participantId)) {
         return this._memberProfiles[i].iconSrc;
       }
     }


### PR DESCRIPTION
Fix Error in js Logs

* Check to see if ```item``` is ```null```  
   before calling ```participantId``` on it.