### PR TITLE
Remove extra home link from social ham nav

### DIFF
--- a/app/views/social_networking/shared/_nav.html.erb
+++ b/app/views/social_networking/shared/_nav.html.erb
@@ -1,5 +1,4 @@
 <%= content_for :mobile_nav_items do %>
-  <li><%= link_to "Home", social_networking.home_path, data: { no_turbolink: true } %></li>
   <li><%= link_to "My Profile", social_networking.social_networking_profile_path, data: { no_turbolink: true } %></li>
 <% end %>
 


### PR DESCRIPTION
* Remove duplicate link to homepage
  from social hamburger navigation.
* Link to home already shows via
  TFDEngine nav bar

[#90940214]