### PR TITLE
Update Email Redirect

### DIFF
--- a/app/controllers/social_networking/comments_controller.rb
+++ b/app/controllers/social_networking/comments_controller.rb
@@ -80,9 +80,11 @@ participant with ID: " + recipient.id.to_s
     end
 
     def message_body
-      ["You've sparked some activity! Log in [#{home_url}] to see \
+      profile_url = social_networking_profile_url
+
+      ["You've sparked some activity! Log in [#{profile_url}] to see \
 who commented on your post.",
-       "Someone commented on your post! Log in [#{home_url}] to\
+       "Someone commented on your post! Log in [#{profile_url}] to\
  learn more."].sample
     end
   end

--- a/spec/controllers/social_networking/comments_controller_spec.rb
+++ b/spec/controllers/social_networking/comments_controller_spec.rb
@@ -134,5 +134,14 @@ module SocialNetworking
         end
       end
     end
+
+    describe "private methods" do
+      describe ".message_body" do
+        it "sends the body text with the social networking profile url" do
+          expect(controller.send(:message_body))
+            .to match %r{/social_networking/profile_page}
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Update Email Redirect

* Change url in email for notifications.
* Url points to social networking profile - not the home page.
* Add spec on private method `message_body`.

[Finishes: #93446774]