### PR TITLE
Fix Profile Page Bugs

### DIFF
--- a/app/assets/javascripts/social_networking/controllers/profile-answer-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/profile-answer-controller.js
@@ -2,42 +2,58 @@
     "use strict";
 
     // Provide interaction with a participant's profile answers to profile questions.
-    function ProfileAnswerCtrl(ProfileAnswers) {
-      var self = this;
-      self._answerResource = ProfileAnswers;
-      self.answerModels = {};
-      self._answerStates = {};
+    function ProfileAnswerCtrl($window, ProfileAnswers) {
+      this._answerResource = ProfileAnswers;
+      this.answerModels = {};
+      this._answerStates = {};
+      this.$window = $window;
     }
 
-    ProfileAnswerCtrl.prototype.storeAnswer = function(profileId, questionId, controller) {
-      this._answerResource.getOne(profileId, questionId)
+    ProfileAnswerCtrl.prototype.storeAnswer = function(profileId, questionId) {
+      var self = this;
+      this
+        ._answerResource.getOne(profileId, questionId)
         .then(function(profileAnswer) {
-          controller.answerModels[questionId] = profileAnswer;
-          controller.setModel(profileAnswer, controller);
-          controller._answerStates[questionId] = {};
-          controller._answerStates[questionId].editable = false;
+          self.answerModels[questionId] = profileAnswer;
+          self.setModel(profileAnswer);
+          self._answerStates[questionId] = {};
+          self._answerStates[questionId].editable = false;
         })
         .catch(function(error) {
-          controller.answerModels[questionId] = {};
+          self.answerModels[questionId] = {};
           var answerModel = {};
           answerModel.profile_id = profileId;
           answerModel.profile_question_id = questionId;
-          controller.answerModels[questionId] = answerModel;
-          controller._answerStates[questionId] = {};
-          controller._answerStates[questionId].editable = true;
+          self.answerModels[questionId] = answerModel;
+          self._answerStates[questionId] = {};
+          self._answerStates[questionId].editable = true;
         });
     };
 
-    ProfileAnswerCtrl.prototype.setModel = function(answer, controller) {
+    ProfileAnswerCtrl.prototype.ifAnswered = function(questions) {
+      var self, states = [];
+
+      self = this;
+      angular.forEach(questions, function(value) {
+        var reponse = self.answerModels[value.id];
+        states.push(reponse && !!reponse.answer_text);
+      });
+      return states.indexOf(true) !== -1;
+    };
+
+    ProfileAnswerCtrl.prototype.setModel = function(answer) {
       var answerModel = {};
+
       answerModel.id = answer.id;
       answerModel.profile_id = answer.profile_id;
       answerModel.profile_question_id = answer.profile_question_id;
       answerModel.answer_text = answer.answer_text;
-      controller.answerModels[answer.profile_question_id] = answerModel;
+      this.answerModels[answer.profile_question_id] = answerModel;
     };
 
-    ProfileAnswerCtrl.prototype.getModel = function(question_id, controller) { return controller.answerModels[question_id]; };
+    ProfileAnswerCtrl.prototype.getModel = function(question_id) {
+      return this.answerModels[question_id];
+    };
 
     // Initiate answer editor interface.
     ProfileAnswerCtrl.prototype.edit = function(question_id) {
@@ -46,33 +62,43 @@
 
     // Exit answer editor interface.
     ProfileAnswerCtrl.prototype.cancelEdit = function(question_id) {
-        this._answerStates[question_id].editable = false;
+      this._answerStates[question_id].editable = false;
     };
 
     // Persist a profile from the form.
-    ProfileAnswerCtrl.prototype.save = function(profileId, questionId, controller) {
+    ProfileAnswerCtrl.prototype.save = function(profileId, questionId) {
+      var answerModel, self = this;
 
-      var answerModel = controller.getModel(questionId, controller);
+      answerModel = this.getModel(questionId);
       if (answerModel.id === undefined) {
         answerModel.profile_id = profileId;
         answerModel.profile_question_id = questionId;
-        controller._answerResource.create(answerModel).then(function() {
-          controller._answerStates[questionId].editable = false;
+        this._answerResource.create(answerModel).then(function() {
+          self.storeAnswer(profileId, questionId);
         }).catch(function(message) {
-        controller.error = message.error;
-      });
+          self.$window.confirm("There was an error: " + message.data.error + ".");
+          self._answerResource.getOne(profileId, questionId)
+            .then(function(profileAnswer) {
+              answerModel.answer_text = profileAnswer.answer_text;
+            })
+            .finally(function(error) {
+              self._answerStates[questionId].editable = false;
+            });
+        });
       } else {
         answerModel.profile_id = profileId;
         answerModel.profile_question_id = questionId;
-        controller._answerResource.update(answerModel).then(function() {
-          controller._answerStates[questionId].editable = false;
+        this._answerResource
+        .update(answerModel)
+        .then(function() {
+          self._answerStates[questionId].editable = false;
         }).catch(function(message) {
-          controller.error = message.error;
+          self.$window.confirm("There was an error: " + message.data.error + ".");
         });
       }
     };
 
     // Create a module and register the controllers.
     angular.module('socialNetworking.controllers')
-      .controller('ProfileAnswerCtrl', ['ProfileAnswers', ProfileAnswerCtrl]);
+      .controller('ProfileAnswerCtrl', ['$window', 'ProfileAnswers', ProfileAnswerCtrl]);
 })();

--- a/app/assets/javascripts/social_networking/resources/profile-answer-resource.js
+++ b/app/assets/javascripts/social_networking/resources/profile-answer-resource.js
@@ -18,7 +18,7 @@
             var answer = new ProfileAnswerResource({
                 profile_id: attributes.profile_id,
                 profile_question_id: attributes.profile_question_id,
-                answer_text: attributes.answer_text
+                answer_text: attributes.answer_text || ""
             });
 
             return answer.$save();
@@ -30,7 +30,7 @@
                 id: attributes.id,
                 profile_id: attributes.profile_id,
                 profile_question_id: attributes.profile_question_id,
-                answer_text: attributes.answer_text
+                answer_text: attributes.answer_text || ""
             });
 
             return answer.$save();

--- a/app/views/social_networking/profile_pages/show.html.erb
+++ b/app/views/social_networking/profile_pages/show.html.erb
@@ -64,48 +64,49 @@
     </div>
   <% end %>
 
-  <h3>Fill out your profile so other group members can get to know you!</h3>
-
-  <ul class="list-group" ng-controller="ProfileQuestionsCtrl as profileQuestions">
+  <div ng-controller="ProfileQuestionsCtrl as profileQuestions">
     <div ng-controller="ProfileAnswerCtrl as answer">
-      <li ng-repeat="question in profileQuestions.questions | orderBy:'order'"
-          class="list-group-item"
-          id="question-{{ question.id }}"
-          ng-init="answer.storeAnswer(<%= @profile.id %>, question.id, answer)">
-        <label for="new-answer-description-{{ question.id }}">{{ question.question_text }}</label>
+      <h3 ng-hide="answer.ifAnswered(profileQuestions.questions)">
+        Fill out your profile so other group members can get to know you!
+      </h3>
+      <ul class="list-group">
+        <li ng-repeat="question in profileQuestions.questions | orderBy:'order'"
+            class="list-group-item"
+            id="question-{{ question.id }}"
+            ng-init="answer.storeAnswer(<%= @profile.id %>, question.id)">
+          <label for="new-answer-description-{{ question.id }}">{{ question.question_text }}</label>
 
-        <form novalidate role="form" name="answerForm" class="row" ng-show="answer._answerStates[question.id].editable">
-          <input type="hidden" name="profile_question_id" value="{{ question.id }}" ng-if="answer.answerModels[question.id].id === null">
-          <input type="hidden" name="profile_id" value="<%= @profile.id %>" ng-if="answer.answerModels[question.id].id === null">
-          <input type="hidden" name="id" ng-if="answer.answerModels[question.id].id !== null">
+          <form novalidate role="form" name="answerForm" class="row" ng-show="answer._answerStates[question.id].editable">
+            <input type="hidden" name="profile_question_id" value="{{ question.id }}" ng-if="answer.answerModels[question.id].id === null">
+            <input type="hidden" name="profile_id" value="<%= @profile.id %>" ng-if="answer.answerModels[question.id].id === null">
+            <input type="hidden" name="id" ng-if="answer.answerModels[question.id].id !== null">
 
-          <div class="form-group col-lg-8 col-md-8">
-            <input type="text" class="form-control" id="new-answer-description-{{question.id}}" ng-model="answer.answerModels[question.id].answer_text" ng-maxlength="255">
+            <div class="form-group col-lg-8 col-md-8">
+              <input type="text" class="form-control" id="new-answer-description-{{question.id}}" ng-model="answer.answerModels[question.id].answer_text" ng-maxlength="255">
+            </div>
+
+            <div class="form-group col-lg-8 col-md-8">
+              <button class="btn btn-primary" ng-click="answer.save(<%= @profile.id %>, question.id)">Save</button>
+            </div>
+          </form>
+
+          <div class="list-group" ng-show="!answer._answerStates[question.id].editable">
+            <p>
+              {{ answer.answerModels[question.id].answer_text }}
+            </p>
+
+            <div class="form-group edit-link">
+              <button class="btn btn-link pull-right edit" ng-click="answer.edit(question.id)"><i class="fa fa-pencil"></i></button>
+            </div>
           </div>
-
-          <div class="form-group col-lg-8 col-md-8">
-            <button class="btn btn-primary" ng-click="answer.save(<%= @profile.id %>, question.id, answer)">Save</button>
-          </div>
-        </form>
-
-        <div class="list-group" ng-show="!answer._answerStates[question.id].editable">
-          <p>
-            {{ answer.answerModels[question.id].answer_text }}
-          </p>
-
-          <% if current_participant.id == @profile.participant_id %>
-          <div class="form-group edit-link">
-            <button class="btn btn-link pull-right edit" ng-click="answer.edit(question.id)"><i class="fa fa-pencil"></i></button>
-          </div>
-          <% end %>
-        </div>
-      </li>
+        </li>
+      </ul>
     </div>
-  </ul>
+  </div>
 <% else %>
   <ul class="list-group" ng-controller="ProfileQuestionsCtrl as profileQuestions">
     <div ng-controller="ProfileAnswerCtrl as answer">
-      <li ng-repeat="question in profileQuestions.questions | orderBy:'order'" class="list-group-item" ng-init="answer.storeAnswer(<%= @profile.id %>, question.id, answer)">
+      <li ng-repeat="question in profileQuestions.questions | orderBy:'order'" class="list-group-item" ng-init="answer.storeAnswer(<%= @profile.id %>, question.id)">
         <strong>{{ question.question_text }}</strong>
 
         <div>
@@ -223,13 +224,10 @@
           .value('noticeUtility', Notice);
 
   function onReady() {
-      if (<%= @profile.participant_id == current_participant.id %> && <%= @profile.icon_name.nil? %>) {
-          $('#profile-icon-selection').modal('show');
-      }
+    if (<%= @profile.participant_id == current_participant.id %> && <%= @profile.icon_name.nil? %>) {
+      $('#profile-icon-selection').modal('show');
+    }
   }
 
-  $(document).ready(onReady);
-  $(document).on("page:load, page:change", function() {
-      angular.bootstrap(document, socialNetworking);
-  });
+  $(document).on("ready page:load page:change", onReady);
 </script>

--- a/spec/javascripts/social_networking/profile/profile-answer-controller_spec.js
+++ b/spec/javascripts/social_networking/profile/profile-answer-controller_spec.js
@@ -1,0 +1,150 @@
+describe('ProfileAnswerCtrl', function() {
+  var $q, $rootScope, $window, answerId, answerText, controller,
+      newAnswer, profileId, profileAnswers, questionId, questions;
+
+  beforeEach(module('socialNetworking.controllers'));
+
+  beforeEach(inject(function($controller, _$rootScope_, _$q_, _$window_) {
+    $rootScope = _$rootScope_;
+    $q = _$q_;
+    $window = _$window_;
+    answerId = 'foo';
+    answerText = 'I love it!';
+    controller = $controller;
+    profileId = 'bar';
+    questionId = 'alas';
+    questions = [
+      {
+        id: questionId,
+        question_text: 'What are your hobbies?'
+      }
+    ];
+    savedAnswer = {
+      id: answerId,
+      answer_text: answerText,
+      profile_id: profileId,
+      profile_question_id: questionId
+    };
+  }));
+
+  describe('#ifAnswered', function() {
+    beforeEach(function() {
+      controller = controller('ProfileAnswerCtrl', {
+        ProfileAnswers: function() {}
+      });
+    });
+
+    it('returns `true` if the participant has answered at least one profile question', function() {
+      controller.answerModels = {}
+      controller.answerModels[questionId] = savedAnswer;
+
+      expect(controller.ifAnswered(questions)).toBe(true);
+    });
+
+    it('returns `false` if the participant has not answered at least one profile question', function() {
+      controller.answerModels = {};
+
+      expect(controller.ifAnswered(questions)).toBe(false);
+    });
+  });
+
+  describe('#save', function() {
+    beforeEach(function() {
+      newAnswer = {
+        answer_text: answerText,
+        profile_id: profileId,
+        profile_question_id: questionId
+      };
+
+      profileAnswers = jasmine.createSpyObj('profileAnswers', ['create', 'getOne']);
+
+      profileAnswers.getOne.and.callFake(function() {
+        var deferred, promise;
+
+        deferred = $q.defer();
+        promise = deferred.promise;
+        deferred.resolve(savedAnswer);
+        return promise;
+      });
+
+      profileAnswers.create();
+    });
+
+    describe('when saving succeeds', function() {
+      beforeEach(function() {
+        profileAnswers.create.and.callFake(function() {
+          var deferred, promise;
+
+          deferred = $q.defer();
+          promise = deferred.promise;
+          deferred.resolve();
+          return promise;
+        });
+
+        controller = controller('ProfileAnswerCtrl', {
+          ProfileAnswers: profileAnswers
+        });
+
+        controller.setModel(newAnswer);
+      });
+
+      it('adds the newly created answer to the collection of answers', function() {
+        expect(controller.answerModels[questionId].id).toBe(undefined);
+
+        controller.save(profileId, questionId);
+        $rootScope.$apply();
+
+        expect(controller.answerModels[questionId]).toEqual(savedAnswer);
+      });
+
+      it('updates the collection of answer states', function() {
+        expect(controller._answerStates[questionId]).toBe(undefined);
+
+        controller.save(profileId, questionId);
+        $rootScope.$apply();
+
+        expect(controller._answerStates[questionId].editable).toBe(false);
+      });
+    });
+
+    describe('answer model is a new object', function() {
+      describe('when saving fails', function() {
+        beforeEach(function() {
+          profileAnswers.create.and.callFake(function() {
+            var deferred, promise;
+
+            deferred = $q.defer();
+            promise = deferred.promise;
+            deferred.reject({ data: { error: 'Holy guacamole!' } });
+            return promise;
+          });
+
+          controller = controller('ProfileAnswerCtrl', {
+            ProfileAnswers: profileAnswers
+          });
+          controller.setModel(newAnswer);
+        });
+
+        it('displays a confirm message to the user', function() {
+          spyOn($window, 'confirm');
+
+          expect($window.confirm).not.toHaveBeenCalled();
+
+          controller.save(profileId, questionId);
+          $rootScope.$apply();
+
+          expect($window.confirm).toHaveBeenCalled();
+        });
+
+        it('does not save the answer to the collection of answers', function() {
+          expect(controller.answerModels[questionId].id).toBe(undefined);
+
+          controller.save(profileId, questionId);
+          $rootScope.$apply();
+
+          expect(controller.answerModels[questionId].id).toBe(undefined);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix Profile Page Bugs

* When participant adds no text, default is set to empty string "".
* Error message is added and fields change back to previous answer.
* After error message, field is no longer focused.
* After creation, profile answer updates the collection in memory.
* Dynamic h3 for alerting user to complete profile.
* h3 disappears once one question has been ansered.
* Add spec to test when `create` for question-profile-answers succeed or fail

[Finished: #98849186]
[Finished: #97428814]