### PR TITLE
Remove erroneous ">>Landing" text on profile pages

### DIFF
--- a/app/controllers/social_networking/profile_pages_controller.rb
+++ b/app/controllers/social_networking/profile_pages_controller.rb
@@ -11,6 +11,7 @@ module SocialNetworking
     end
 
     def show
+      current_participant.navigation_status.context = nil
       if params[:id].present?
         @profile = Profile.find(params[:id])
         store_nudge_initiators(@profile.participant_id)


### PR DESCRIPTION
 * Modify profile page controller to set the navigation context to nil, otherwise the context when navigating to the profile page is just whatever it was for the previous page

[Finished: 97469756]