### PR TITLE
Change how default admin name is handled

### DIFF
--- a/app/models/social_networking/profile.rb
+++ b/app/models/social_networking/profile.rb
@@ -30,11 +30,7 @@ module SocialNetworking
     end
 
     def user_name
-      if participant.is_admin
-        "ThinkFeelDo"
-      else
-        participant.display_name
-      end
+      participant.display_name
     end
   end
 end


### PR DESCRIPTION
 * Remove `ThinkFeelDo` as default admin name
 * Applications will now set their own default admin name by overriding `user_name` in the Profile class

[Finished: #97469840]