### PR TITLE
Make moderator display name depend on application

### DIFF
--- a/app/models/social_networking/profile.rb
+++ b/app/models/social_networking/profile.rb
@@ -34,7 +34,11 @@ module SocialNetworking
     end
 
     def user_name
-      participant.display_name
+      if participant.is_admin
+        Rails.application.config.moderating_participant_display_name
+      else
+        participant.display_name
+      end
     end
   end
 end


### PR DESCRIPTION
 * Set the `user_name` to display admin names based on app here rather than having to override in the apps themselves

[Finished: #97469840]