### PR TITLE
Add unit tests and make nudge email subject app-specific

### DIFF
--- a/app/controllers/social_networking/nudges_controller.rb
+++ b/app/controllers/social_networking/nudges_controller.rb
@@ -65,7 +65,8 @@ module SocialNetworking
       NudgeMailer.nudge_email_alert(
         Participant.find(nudge.recipient_id),
         message_body,
-        "You've been NUDGED on ThinkFeelDo").deliver
+        "You've been NUDGED on "\
+        "#{t 'application_name', default: 'ThinkFeelDo' }").deliver
     end
 
     def message_body

--- a/config/initializers/think_feel_do_dashboard.rb
+++ b/config/initializers/think_feel_do_dashboard.rb
@@ -1,0 +1,2 @@
+#Set default display/user name for the group moderator of social arms
+Rails.application.config.moderating_participant_display_name = "Social Networking"

--- a/spec/controllers/social_networking/nudges_controller_spec.rb
+++ b/spec/controllers/social_networking/nudges_controller_spec.rb
@@ -56,6 +56,27 @@ module SocialNetworking
             allow(controller).to receive(:send_sms) { nil }
           end
 
+          it "sends an email alert with the localized app name" do
+            allow(controller).to receive(:t)
+              .with("application_name", default: "ThinkFeelDo")
+              .and_return("SunnySide")
+            expect(NudgeMailer).to receive(:nudge_email_alert)
+              .with(anything, anything, "You've been NUDGED on SunnySide")
+            allow(NudgeMailer)
+              .to receive_message_chain(:nudge_email_alert, :deliver)
+
+            post :create, recipientId: 123
+          end
+
+          it "sends an email alert with a default app name if none is found" do
+            expect(NudgeMailer).to receive(:nudge_email_alert)
+              .with(anything, anything, "You've been NUDGED on ThinkFeelDo")
+            allow(NudgeMailer)
+              .to receive_message_chain(:nudge_email_alert, :deliver)
+
+            post :create, recipientId: 123
+          end
+
           it "should return the new record" do
             expect(NudgeMailer)
               .to receive_message_chain(:nudge_email_alert, :deliver)

--- a/spec/models/social_networking/profile_spec.rb
+++ b/spec/models/social_networking/profile_spec.rb
@@ -4,15 +4,32 @@ module SocialNetworking
   describe Profile, type: :model do
     fixtures :all
 
+    let(:participant) { participants(:participant1) }
+
     describe "#started" do
       it "returns false if the participant hasn't answered any questions" do
         expect(Profile.create(
-          participant: participants(:participant1))
-        .started?).to eq false
+          participant: participant).started?).to eq false
       end
 
       it "returns true if the participant has answered at least one question" do
         expect(social_networking_profiles(:profile2).started?).to eq true
+      end
+    end
+
+    describe "#user_name" do
+      it "does not replace the display_name of a normal participant" do
+        allow(participant).to receive(:is_admin).and_return(false)
+        expect(
+          Profile.create(participant: participant).user_name
+              ).to eq("display name")
+      end
+
+      it "replaces the display_name of a moderator with an app-specific name" do
+        allow(participant).to receive(:is_admin).and_return(true)
+        expect(
+          Profile.create(participant: participant).user_name
+              ).to eq("Social Networking")
       end
     end
   end


### PR DESCRIPTION
 * Add unit tests for multiple methods that replace "ThinkFeelDo" with the host app name
 * Make the subject of the email notification for nudges say the actual app name instead of just "ThinkFeelDo"

[Finished: #97469840]
[Finished: #97470102]