### PR TITLE
Msw 99741330 update nudge route for email notifications

### DIFF
--- a/app/assets/javascripts/social_networking/controllers/profile-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/profile-controller.js
@@ -7,7 +7,8 @@
       self._profiles = Profiles;
       self._nudges = Nudges;
       self.profile = {};
-      self._profiles.getOne(profileId).then(function(profile) {
+      self._profiles.getOne(profileId)
+      .then(function(profile) {
           self.id = profile.id;
           self.profile = profile;
           self.iconSrc = '';
@@ -21,8 +22,11 @@
     var self = this;
 
     this._nudges.create(recipient_id)
-      .then(function() {
-        self.nudgeAlert = "Nudge sent!";
+      .then(function(response) {
+        self.nudgeAlert = response.message;
+      })
+      .catch(function(response) {
+        self.nudgeAlert = response.data.error;
       });
   };
 

--- a/app/controllers/concerns/sms.rb
+++ b/app/controllers/concerns/sms.rb
@@ -12,8 +12,8 @@ module Sms
   def send_sms(recipient = current_user, message_body)
     return if recipient.phone_number.blank?
 
-    logger.info("INFO BEFORE: SMS notification sent \
-                 to:" + recipient.phone_number)
+    logger.info "INFO BEFORE: SMS notification sent "\
+                "to: #{recipient.phone_number}"
     if recipient.is_a?(Participant)
       if Rails.env.staging? || Rails.env.production?
         client = Twilio::REST::Client.new(
@@ -22,14 +22,14 @@ module Sms
         account = client.account
         account.messages.create(message_attributes(recipient, message_body))
       else
-        logger.info("INFO - SMS attributes: " \
-                    "#{ message_attributes(recipient, message_body) }")
+        logger.info "INFO - SMS attributes: "\
+                    "#{message_attributes(recipient, message_body)}"
       end
     else
       logger.error "Error: Expected recipient to be a Participant."
     end
-    logger.info("INFO AFTER: SMS notification sent \
-                 to:" + recipient.phone_number)
+    logger.info "INFO AFTER: SMS notification sent "\
+                "to: #{recipient.phone_number}"
   end
   # rubocop:enable Metrics/AbcSize
 
@@ -38,9 +38,9 @@ module Sms
   def message_attributes(recipient, body)
     {
       from:
-        "#{ Rails.application.config.twilio_account_telephone_number }",
+        "#{Rails.application.config.twilio_account_telephone_number}",
       to:
-        "+#{ recipient.phone_number }",
+        "+#{recipient.phone_number}",
       body:
         body
     }

--- a/app/controllers/social_networking/nudges_controller.rb
+++ b/app/controllers/social_networking/nudges_controller.rb
@@ -32,8 +32,6 @@ module SocialNetworking
 
     # Select message from list, determine contact preference, then
     # trigger the notification based on the preference.
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
     def notify
       recipient = Participant.find(sanitized_params[:recipient_id])
 
@@ -41,20 +39,14 @@ module SocialNetworking
       when "email"
         send_notify_email(@nudge, message_body)
       when "sms"
-        if recipient.phone_number && !recipient.phone_number.blank?
-          send_sms(recipient, message_body)
-        end
+        send_sms(recipient, message_body) if recipient.phone_number.present?
       when "phone"
-        if recipient.phone_number && !recipient.phone_number.blank?
-          send_sms(recipient, message_body)
-        end
+        send_sms(recipient, message_body) if recipient.phone_number.present?
       else
         logger.error "ERROR: contact preference is not set for \
-        participant with ID: " + recipient.id
+        participant with ID: #{recipient.id}"
       end
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def model_errors
       @nudge.errors.full_messages.join(", ")
@@ -70,7 +62,7 @@ module SocialNetworking
     end
 
     def message_body
-      site_root_url = home_url
+      site_root_url = social_networking_profile_url
       ["You've been nudged by #{current_participant.display_name}! Log \
 in (#{site_root_url}) to find out who nudged you.",
        "#{current_participant.display_name} just nudged you! Log in \

--- a/app/models/social_networking/concerns/participant.rb
+++ b/app/models/social_networking/concerns/participant.rb
@@ -3,6 +3,7 @@ module SocialNetworking
     # adds associations to Participant class
     module Participant
       extend ActiveSupport::Concern
+
       included do
         has_many :social_networking_comments,
                  class_name: "SocialNetworking::Comment",
@@ -27,6 +28,15 @@ module SocialNetworking
         has_one :social_networking_profile,
                 class_name: "SocialNetworking::Profile",
                 dependent: :destroy
+
+        validates :email, presence: true, if: "contact_preference == 'email'"
+        validates :phone_number, presence: true, if: :phone_number?
+
+        private
+
+        def phone_number?
+          %w(sms phone).include?(contact_preference)
+        end
       end
     end
   end

--- a/spec/controllers/social_networking/nudges_controller_spec.rb
+++ b/spec/controllers/social_networking/nudges_controller_spec.rb
@@ -4,100 +4,110 @@ module SocialNetworking
   describe NudgesController, type: :controller do
     describe "POST create" do
       context "when the participant is authenticated" do
-        let(:participant) do
-          double("participant",
-                 id: 987,
-                 contact_preference: "sms",
-                 phone_number: "16309101110",
-                 email: "test@tester.com",
-                 display_name: "hamburger",
-                 is_admin: false)
-        end
-        let(:nudge) do
-          double("nudge",
-                 id: 8_675_309,
-                 created_at: DateTime.new,
-                 initiator: participant,
-                 initiator_id: participant.id,
-                 recipient_id: 123,
-                 comments: [])
-        end
-        let(:receiver) do
-          double(
-            "receiver",
-            id: 123,
-            email: "test@tester.com",
-            contact_preference: "email",
-            phone_number: "16309201110"
-          )
-        end
+        let(:nudge) { double("nudge", recipient_id: 1) }
+        let(:participant) { double("participant", id: 1, display_name: "joe") }
 
         before do
           @routes = Engine.routes
-          allow(controller).to receive(:authenticate_participant!)
           allow(controller).to receive(:current_participant) { participant }
-
-          expect(Nudge).to receive(:new).with(
-            initiator_id: participant.id,
-            recipient_id: "123"
-          ) { nudge }
-
-          allow(Profile).to receive(:find_by_participant_id)
-            .and_return(double("profile", user_name: "F. Bar"))
-          allow(nudge).to receive(:save) { true }
-          allow(Participant).to receive(:find) { participant }
-          allow(controller).to receive(:send_sms) { nil }
+          allow(Serializers::NudgeSerializer)
+            .to receive_message_chain(:new, :to_serialized)
+            .and_return(foo: :bar)
+          allow(Nudge).to receive(:new) { nudge }
         end
 
-        context "and the record saves" do
+        context "record saves" do
+          let(:logger) { Rails.logger }
+
+          def recipient(attributes = {})
+            double("recipient", attributes)
+          end
+
           before do
+            allow(logger).to receive(:error)
+            allow(logger).to receive(:info)
             allow(nudge).to receive(:save) { true }
-            allow(Participant).to receive(:find) { receiver }
-            allow(controller).to receive(:send_sms) { nil }
           end
 
-          it "sends an email alert with the localized app name" do
-            allow(controller).to receive(:t)
-              .with("application_name", default: "ThinkFeelDo")
-              .and_return("SunnySide")
-            expect(NudgeMailer).to receive(:nudge_email_alert)
-              .with(anything, anything, "You've been NUDGED on SunnySide")
-            allow(NudgeMailer)
-              .to receive_message_chain(:nudge_email_alert, :deliver)
+          describe "recipient has no contact preference" do
+            it "should return serialized nudge" do
+              allow(Participant).to receive(:find) do
+                recipient(id: 1, contact_preference: nil)
+              end
 
-            post :create, recipientId: 123
+              expect(logger).to receive(:error)
+
+              post :create
+
+              assert_response 200
+              expect(json["foo"]).to eq("bar")
+            end
           end
 
-          it "sends an email alert with a default app name if none is found" do
-            expect(NudgeMailer).to receive(:nudge_email_alert)
-              .with(anything, anything, "You've been NUDGED on ThinkFeelDo")
-            allow(NudgeMailer)
-              .to receive_message_chain(:nudge_email_alert, :deliver)
+          describe "recipient prefers to be contacted via phone" do
+            it "should notify via phone" do
+              allow(Participant).to receive(:find) do
+                recipient(contact_preference: "phone", phone_number: "#")
+              end
 
-            post :create, recipientId: 123
+              expect(logger).to receive(:info)
+
+              post :create
+            end
           end
 
-          it "should return the new record" do
-            expect(NudgeMailer)
-              .to receive_message_chain(:nudge_email_alert, :deliver)
-            post :create, recipientId: 123
+          describe "recipient prefers to be contacted via sms" do
+            it "should notify via sms" do
+              allow(Participant).to receive(:find) do
+                recipient(contact_preference: "sms", phone_number: "#")
+              end
 
-            assert_response 200
-            expect(json["id"]).to eq(8_675_309)
-            expect(json["recipientId"]).to eq(123)
-            expect(json["initiatorId"]).to eq(987)
+              expect(logger).to receive(:info)
+
+              post :create
+            end
+          end
+
+          describe "recipient prefers to be contacted via email" do
+            before do
+              allow(Participant).to receive(:find) do
+                recipient(contact_preference: "email", email: "mia@ex.co")
+              end
+              allow(NudgeMailer)
+                .to receive_message_chain(:nudge_email_alert, :deliver)
+            end
+
+            it "sends an email alert with a default app name" do
+              expect(NudgeMailer).to receive(:nudge_email_alert)
+                .with(anything, anything, "You've been NUDGED on ThinkFeelDo")
+
+              post :create
+            end
+
+            it "should notify via email alert with the localized app name" do
+              allow(controller).to receive(:t).and_return("SunnySide")
+
+              expect(NudgeMailer).to receive(:nudge_email_alert)
+                .with(anything, anything, "You've been NUDGED on SunnySide")
+
+              post :create
+            end
+
+            it "should contain email that redirects patient to their profile" do
+              expect(NudgeMailer).to receive(:nudge_email_alert)
+                .with(anything, %r{/social_networking/profile_page}, anything)
+
+              post :create
+            end
           end
         end
 
-        context "and the record doesn't save" do
+        context "record doesn't save" do
           let(:errors) { double("errors", full_messages: ["baz"]) }
 
-          before do
-            allow(nudge).to receive_messages(save: false, errors: errors)
-          end
-
           it "should return the error message" do
-            post :create, recipientId: 123
+            allow(nudge).to receive_messages(save: false, errors: errors)
+            post :create
 
             assert_response 400
             expect(json["error"]).to eq("baz")

--- a/spec/dummy/app/models/participant.rb
+++ b/spec/dummy/app/models/participant.rb
@@ -1,4 +1,6 @@
 class Participant < ActiveRecord::Base
+  include SocialNetworking::Concerns::Participant
+
   def active_membership_end_date
     Date.today.advance(weeks: 8)
   end

--- a/spec/models/social_networking/concerns/participant_spec.rb
+++ b/spec/models/social_networking/concerns/participant_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+module SocialNetworking
+  module Concerns
+    RSpec.describe Participant do
+      describe "validations" do
+        context "contact preference is selected" do
+          it "is invalid if email is not provided" do
+            expect(::Participant
+              .new(contact_preference: "email")
+              .tap(&:valid?)
+              .errors[:email]).to include "can't be blank"
+          end
+
+          it "is invalid if phone number is not provided" do
+            expect(::Participant
+              .new(contact_preference: "sms")
+              .tap(&:valid?)
+              .errors[:phone_number]).to include "can't be blank"
+          end
+
+          it "is invalid if phone number is not provided" do
+            expect(::Participant
+              .new(contact_preference: "phone")
+              .tap(&:valid?)
+              .errors[:phone_number]).to include "can't be blank"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Update nudge notification email to point to profile page.
* Refactored nudge controller and participant concern specs.
* Display custom alert message from controller.
* Move the validation logic to a participant concern.
* Add validation concern specs

[#99741330]