### PR TITLE
Add Scoping When Allowing Updating

### DIFF
--- a/app/controllers/social_networking/profile_answers_controller.rb
+++ b/app/controllers/social_networking/profile_answers_controller.rb
@@ -26,7 +26,7 @@ module SocialNetworking
     end
 
     def create
-      profile_id = Profile.find_by_participant_id(current_participant.id).id
+      profile_id = current_participant.social_networking_profile.try(:id)
       @profile_answer = ProfileAnswer
                         .new(social_networking_profile_id: profile_id,
                              social_networking_profile_question_id:
@@ -42,7 +42,9 @@ module SocialNetworking
     end
 
     def update
-      @profile_answer = ProfileAnswer
+      @profile_answer = current_participant
+                        .social_networking_profile
+                        .profile_answers
                         .where(id: profile_answer_params[:id]).first! ||
                         fail(ActiveRecord::RecordNotFound)
 

--- a/app/controllers/social_networking/profiles_controller.rb
+++ b/app/controllers/social_networking/profiles_controller.rb
@@ -30,16 +30,18 @@ module SocialNetworking
     end
 
     def update
-      profile = Profile.find(profile_params[:id])
-      profile.update(icon_name: profile_params[:icon_name])
-
-      render json: Serializers::ProfileSerializer.new(profile).to_serialized
+      profile = current_participant.social_networking_profile.find(params[:id])
+      if profile.update(icon_name: profile_params[:icon_name])
+        render json: Serializers::ProfileSerializer.new(profile).to_serialized
+      else
+        render json: { error: profile.errors.full_messages }, status: 400
+      end
     end
 
     private
 
     def profile_params
-      params.permit(:profile, :id, :icon_name)
+      params.permit(:id, :icon_name)
     end
 
     def record_not_found

--- a/spec/controllers/social_networking/profile_answers_controller_spec.rb
+++ b/spec/controllers/social_networking/profile_answers_controller_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+module SocialNetworking
+  describe ProfileAnswersController, type: :controller do
+    context "participant is authenticated" do
+      let(:participant) { double("participant") }
+      let(:answer) { double("profile_answer") }
+      let(:errors) { double("errors", full_messages: ["epic fail"]) }
+
+      before do
+        @routes = Engine.routes
+        allow(controller).to receive(:authenticate_participant!)
+        allow(controller).to receive(:current_participant) { participant }
+      end
+
+      describe "POST create" do
+        before do
+          allow(participant)
+            .to receive_message_chain(:social_networking_profile, :id)
+          allow(ProfileAnswer).to receive(:new) { answer }
+        end
+
+        context "create succeeds" do
+          it "renders the serialized answer" do
+            allow(answer).to receive(:save) { true }
+
+            expect(Serializers::ProfileAnswerSerializer)
+              .to receive_message_chain(:new, :to_serialized)
+
+            post :create
+          end
+        end
+
+        context "create fails" do
+          it "renders error message" do
+            allow(answer).to receive_messages(save: false, errors: errors)
+            post :create
+
+            assert_response 400
+            expect(json["error"]).to eq "epic fail"
+          end
+        end
+      end
+
+      describe "POST update" do
+        context "profile answer is not found" do
+          it "renders error message" do
+            allow(participant)
+              .to receive_message_chain(:social_networking_profile,
+                                        :profile_answers,
+                                        :where,
+                                        :first!)
+            post :update, id: 1
+
+            assert_response 404
+            expect(json["error"]).to eq "profile not found"
+          end
+        end
+
+        context "profile answer is found" do
+          before do
+            allow(participant)
+              .to receive_message_chain(:social_networking_profile,
+                                        :profile_answers,
+                                        :where,
+                                        :first!) { answer }
+          end
+
+          context "update succeeds" do
+            it "renders the serialized answer" do
+              allow(answer).to receive(:update) { true }
+
+              expect(Serializers::ProfileAnswerSerializer)
+                .to receive_message_chain(:new, :to_serialized)
+
+              post :update, id: 1
+            end
+          end
+
+          context "update fails" do
+            let(:errors) { double("errors", full_messages: ["epic fail"]) }
+
+            it "renders error message" do
+              allow(answer).to receive_messages(update: false, errors: errors)
+              post :update, id: 1
+
+              assert_response 400
+              expect(json["error"]).to eq "epic fail"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/social_networking/profiles_controller_spec.rb
+++ b/spec/controllers/social_networking/profiles_controller_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+module SocialNetworking
+  describe ProfilesController, type: :controller do
+    context "participant is authenticated" do
+      let(:participant) { double("participant") }
+      let(:profile) { double("profile") }
+
+      before do
+        @routes = Engine.routes
+        allow(controller).to receive(:current_participant) { participant }
+        allow(participant)
+          .to receive_message_chain(:social_networking_profile,
+                                    :find) { profile }
+      end
+
+      describe "PUT update" do
+        context "update succeeds" do
+          it "renders serialized profile" do
+            allow(profile).to receive_messages(update: true)
+
+            expect(Serializers::ProfileSerializer)
+              .to receive_message_chain(:new, :to_serialized)
+
+            put :update, icon_name: "purse", id: 1
+
+            assert_response 200
+          end
+        end
+
+        context "update fails" do
+          let(:errors) { double("errors", full_messages: ["epic fail"]) }
+
+          it "renders error message" do
+            allow(profile).to receive_messages(update: false, errors: errors)
+            put :update, icon_name: "purse", id: 1
+
+            assert_response 400
+            expect(json["error"]).to eq ["epic fail"]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Scoping When Allowing Updating

* Participant can only update his/her own profile questions.
* Profile answers are now scoped to a participant's profile.
* Now, the only profile icons a participant can update is his/her own profile icon.
* Add controller specs for updating profile questions and icon.

[Finished: #99072664]