### PR TITLE
Fix Updating Profile Icon

### DIFF
--- a/app/assets/javascripts/social_networking/controllers/profile-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/profile-controller.js
@@ -2,51 +2,48 @@
   "use strict";
 
   // Provide interaction with a participant's profile.
-  function ProfileCtrl(profileId, Profiles, Nudges) {
+  function ProfileCtrl(alertService, profileId, Profiles, Nudges) {
       var self = this;
-      self._profiles = Profiles;
-      self._nudges = Nudges;
-      self.profile = {};
-      self._profiles.getOne(profileId)
-      .then(function(profile) {
-          self.id = profile.id;
-          self.profile = profile;
-          self.iconSrc = '';
+      this._profiles = Profiles;
+      this._nudges = Nudges;
+      this.alertService = alertService;
+      this.profile = {};
+      this._profiles.getOne(profileId).then(function(profile) {
+        self.id = profile.id;
+        self.profile = profile;
+        self.iconSrc = '';
       }).catch(function(error) {
-          window.console.log(error);
+        self.alertService.addError(error);
       });
   }
 
   // Send a nudge from one participant to another.
-  ProfileCtrl.prototype.nudge = function(recipient_id) {
+  ProfileCtrl.prototype.nudge = function(recipientId) {
     var self = this;
 
-    this._nudges.create(recipient_id)
+    this._nudges.create(recipientId)
       .then(function(response) {
         self.nudgeAlert = response.message;
       })
       .catch(function(response) {
-        self.nudgeAlert = response.data.error;
+        self.alertService.addError(response.data.error);
       });
   };
 
-  // Update the profile icon
-  ProfileCtrl.prototype.update_profile_icon = function(icon_name, controller) {
-    controller.iconSrc = icon_name;
-    controller._profiles.update(controller).then(function(profile) {
-      controller.profile.iconSrc = profile.iconSrc;
+  ProfileCtrl.prototype.updateProfileIcon = function(iconName) {
+    var self = this;
+    this.iconSrc = iconName;
+    this._profiles.update(this)
+    .then(function(profile) {
+      self.profile.iconSrc = profile.iconSrc;
     })
     .catch(function(response) {
-      window.alert(response.data.error);
+      self.alertService.addError(response.data.error);
     });
     $('#icon-selection-button').click();
   };
 
-  ProfileCtrl.prototype.getIconSrc = function(controller) {
-    return controller.profile.iconSrc;
-  };
-
   // Create a module and register the controllers.
   angular.module('socialNetworking.controllers')
-    .controller('ProfileCtrl', ['profileId', 'Profiles', 'Nudges', ProfileCtrl]);
+    .controller('ProfileCtrl', ['alertService', 'profileId', 'Profiles', 'Nudges', ProfileCtrl]);
 })();

--- a/app/assets/javascripts/social_networking/controllers/profile-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/profile-controller.js
@@ -34,7 +34,10 @@
   ProfileCtrl.prototype.update_profile_icon = function(icon_name, controller) {
     controller.iconSrc = icon_name;
     controller._profiles.update(controller).then(function(profile) {
-        controller.profile.iconSrc = profile.iconSrc;
+      controller.profile.iconSrc = profile.iconSrc;
+    })
+    .catch(function(response) {
+      window.alert(response.data.error);
     });
     $('#icon-selection-button').click();
   };

--- a/app/assets/javascripts/social_networking/controllers/profile-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/profile-controller.js
@@ -7,13 +7,17 @@
       this._profiles = Profiles;
       this._nudges = Nudges;
       this.alertService = alertService;
+      this.getAlerts = alertService.alerts;
       this.profile = {};
+      this.removeAlert = function(alert) {
+        alertService.removeAlert(alert);
+      };
       this._profiles.getOne(profileId).then(function(profile) {
         self.id = profile.id;
         self.profile = profile;
         self.iconSrc = '';
       }).catch(function(error) {
-        self.alertService.addError(error);
+        alertService.addError(error);
       });
   }
 

--- a/app/assets/javascripts/social_networking/controllers/profile-controller.js
+++ b/app/assets/javascripts/social_networking/controllers/profile-controller.js
@@ -7,7 +7,9 @@
       this._profiles = Profiles;
       this._nudges = Nudges;
       this.alertService = alertService;
-      this.getAlerts = alertService.alerts;
+      this.getAlerts = function() {
+        return alertService.getAlerts();
+      };
       this.profile = {};
       this.removeAlert = function(alert) {
         alertService.removeAlert(alert);

--- a/app/assets/javascripts/social_networking/services/Alert.js
+++ b/app/assets/javascripts/social_networking/services/Alert.js
@@ -7,16 +7,19 @@
     return {
       alerts: [],
       addError: function(message) {
-        this.alerts.push({
+        this.getAlerts().push({
           cssClass: ErrorClass,
           message: message
         });
       },
+      getAlerts: function() {
+        return this.alerts;
+      },
       removeAlert: function(alert) {
         var index;
 
-        index = this.alerts.indexOf(alert);
-        this.alerts.splice(index, 1);
+        index = this.getAlerts().indexOf(alert);
+        this.getAlerts().splice(index, 1);
       }
     };
   }

--- a/app/assets/javascripts/social_networking/services/Alert.js
+++ b/app/assets/javascripts/social_networking/services/Alert.js
@@ -1,0 +1,20 @@
+;(function() {
+  'use strict';
+
+  var ErrorClass = "alert-danger";
+
+  function alertService() {
+    return {
+      alerts: [],
+      addError: function(message) {
+        this.alerts.push({
+          cssClass: ErrorClass,
+          message: message
+        });
+      }
+    };
+  }
+
+  angular.module('socialNetworking.services')
+    .factory('alertService', [alertService]);
+})();

--- a/app/assets/javascripts/social_networking/services/Alert.js
+++ b/app/assets/javascripts/social_networking/services/Alert.js
@@ -11,6 +11,12 @@
           cssClass: ErrorClass,
           message: message
         });
+      },
+      removeAlert: function(alert) {
+        var index;
+
+        index = this.alerts.indexOf(alert);
+        this.alerts.splice(index, 1);
       }
     };
   }

--- a/app/controllers/social_networking/profile_pages_controller.rb
+++ b/app/controllers/social_networking/profile_pages_controller.rb
@@ -11,10 +11,11 @@ module SocialNetworking
     end
 
     def show
-      current_participant.navigation_status.context = nil
       if params[:id].present?
         @profile = Profile.find(params[:id])
         store_nudge_initiators(@profile.participant_id)
+      elsif current_participant.social_networking_profile
+        @profile = current_participant.social_networking_profile
       else
         @profile = Profile
                    .find_or_create_by(participant_id: current_participant.id,

--- a/app/controllers/social_networking/profile_pages_controller.rb
+++ b/app/controllers/social_networking/profile_pages_controller.rb
@@ -38,13 +38,9 @@ module SocialNetworking
     end
 
     def store_nudge_initiators(participant_id)
-      @nudging_display_names = []
-      Nudge
-        .search(participant_id)
-        .each do |notification|
-        @nudging_display_names.push(
-          notification.initiator.display_name)
-      end
+      @nudging_display_names =  Nudge
+                                .search(participant_id)
+                                .map { |n| n.initiator.display_name }
     end
 
     def set_profile_questions

--- a/app/controllers/social_networking/profiles_controller.rb
+++ b/app/controllers/social_networking/profiles_controller.rb
@@ -30,8 +30,8 @@ module SocialNetworking
     end
 
     def update
-      profile = current_participant.social_networking_profile.find(params[:id])
-      if profile.update(icon_name: profile_params[:icon_name])
+      profile = current_participant.social_networking_profile
+      if profile.update(profile_params)
         render json: Serializers::ProfileSerializer.new(profile).to_serialized
       else
         render json: { error: profile.errors.full_messages }, status: 400
@@ -41,7 +41,7 @@ module SocialNetworking
     private
 
     def profile_params
-      params.permit(:id, :icon_name)
+      params.permit(:icon_name)
     end
 
     def record_not_found

--- a/app/models/social_networking/nudge.rb
+++ b/app/models/social_networking/nudge.rb
@@ -13,7 +13,7 @@ module SocialNetworking
 
     validates :initiator, :recipient, presence: true
 
-    def self.search(recipient_id)
+    def self.search(recipient_id = nil)
       if recipient_id
         select(:initiator_id)
           .where(recipient_id: recipient_id)

--- a/app/models/social_networking/profile.rb
+++ b/app/models/social_networking/profile.rb
@@ -12,7 +12,9 @@ module SocialNetworking
     has_many :comments, as: "item"
     has_many :likes, as: "item"
 
-    validates :participant, presence: true
+    validates :participant,
+              presence: true,
+              uniqueness: { scope: :participant_id }
 
     delegate :latest_action_at, :active_membership_end_date,
              to: :participant

--- a/app/models/social_networking/profile.rb
+++ b/app/models/social_networking/profile.rb
@@ -14,6 +14,7 @@ module SocialNetworking
     has_many :comments, as: "item"
     has_many :likes, as: "item"
 
+    validates :participant, presence: true
     validates :participant_id, uniqueness: true
 
     delegate :latest_action_at, :active_membership_end_date,

--- a/app/models/social_networking/profile.rb
+++ b/app/models/social_networking/profile.rb
@@ -4,6 +4,8 @@ module SocialNetworking
     ACTION_TYPES = %w( created completed )
     Actions = Struct.new(*ACTION_TYPES.map(&:to_sym)).new(*ACTION_TYPES)
 
+    after_create :share_profile
+
     belongs_to :participant
     has_many :profile_answers,
              class_name: "SocialNetworking::ProfileAnswer",
@@ -12,9 +14,7 @@ module SocialNetworking
     has_many :comments, as: "item"
     has_many :likes, as: "item"
 
-    validates :participant,
-              presence: true,
-              uniqueness: { scope: :participant_id }
+    validates :participant_id, uniqueness: true
 
     delegate :latest_action_at, :active_membership_end_date,
              to: :participant
@@ -41,6 +41,14 @@ module SocialNetworking
       else
         participant.display_name
       end
+    end
+
+    private
+
+    def share_profile
+      SharedItem.create(
+        item: self,
+        action_type: Profile::Actions.created)
     end
   end
 end

--- a/app/views/social_networking/profile_pages/show.html.erb
+++ b/app/views/social_networking/profile_pages/show.html.erb
@@ -57,10 +57,10 @@
 </div>
 
 <% if current_participant.id == @profile.participant_id %>
-  <% unless @nudges.empty? %>
-    <div class="alert alert-info" id="nudge-alert">
-      <button type="button" class="close" data-dismiss="alert" onclick="$('#nudge-alert').hide();"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-      <%= @nudges.to_sentence %> nudged you!
+  <% unless @nudging_display_names.empty? %>
+    <div class="alert alert-info">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+      <%= @nudging_display_names.to_sentence %> nudged you!
     </div>
   <% end %>
   <div ng-controller="ProfileQuestionsCtrl as profileQuestions">

--- a/app/views/social_networking/profile_pages/show.html.erb
+++ b/app/views/social_networking/profile_pages/show.html.erb
@@ -14,7 +14,7 @@
           <div class="modal-body">
             <% @profile_icons.each_with_index do |icon_name, index| %>
               <% if 0 == index % 6 %><div class="row"><% end %>
-              <div ng-click="profile.update_profile_icon('<%= icon_name %>', profile)" class="col-lg-2 col-sm-4 col-xs-4 text-center icon-selection">
+              <div ng-click="profile.updateProfileIcon('<%= icon_name %>')" class="col-lg-2 col-sm-4 col-xs-4 text-center icon-selection">
                 <%= image_tag 'social_networking/profile_icon_'+ icon_name +'.png' %>
               </div>
               <% if 5 == index % 6 || index + 1 == @profile_icons.size %></div><% end %>
@@ -53,6 +53,14 @@
         <br><span>{{ profile.nudgeAlert }}</span>
       </div>
     <% end %>
+  </div>
+
+  <div ng-repeat="alert in profile.alertService.alerts" class="alert {{alert.cssClass}}">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+      <span class="sr-only">Close</span>
+    </button>
+    {{alert.message}}
   </div>
 </div>
 

--- a/app/views/social_networking/profile_pages/show.html.erb
+++ b/app/views/social_networking/profile_pages/show.html.erb
@@ -55,7 +55,7 @@
     <% end %>
   </div>
 
-  <div ng-repeat="alert in profile.getAlerts" class="alert {{alert.cssClass}}">
+  <div ng-repeat="alert in profile.getAlerts()" class="alert {{alert.cssClass}}">
     <button type="button" class="close" data-dismiss="alert" aria-label="Close" ng-click="profile.removeAlert(alert)">
       <span aria-hidden="true">&times;</span>
       <span class="sr-only">Close</span>

--- a/app/views/social_networking/profile_pages/show.html.erb
+++ b/app/views/social_networking/profile_pages/show.html.erb
@@ -55,8 +55,8 @@
     <% end %>
   </div>
 
-  <div ng-repeat="alert in profile.alertService.alerts" class="alert {{alert.cssClass}}">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+  <div ng-repeat="alert in profile.getAlerts" class="alert {{alert.cssClass}}">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close" ng-click="profile.removeAlert(alert)">
       <span aria-hidden="true">&times;</span>
       <span class="sr-only">Close</span>
     </button>

--- a/spec/controllers/social_networking/profile_pages_controller_spec.rb
+++ b/spec/controllers/social_networking/profile_pages_controller_spec.rb
@@ -5,12 +5,11 @@ module SocialNetworking
     let(:group) { double("group", social_networking_profile_questions: []) }
     let(:participant_status) { double("participant_status", :context= => "") }
     let(:participant) do
-      double(
-        "participant",
-        active_group: group,
-        navigation_status: participant_status)
+      instance_double(
+        Participant,
+        active_group: group)
     end
-    let(:initiator) { double("participant") }
+    let(:initiator) { instance_double(Participant) }
 
     describe "GET show" do
       context "when the current participant is authenticated" do
@@ -26,7 +25,7 @@ module SocialNetworking
           end
 
           context "current participant has been nudged" do
-            let(:nudge) { double("nudge", initiator: initiator) }
+            let(:nudge) { instance_double(Nudge, initiator: initiator) }
 
             it "displays the display name of the participant who nudged" do
               allow(Nudge).to receive(:search) { [nudge] }

--- a/spec/controllers/social_networking/profile_pages_controller_spec.rb
+++ b/spec/controllers/social_networking/profile_pages_controller_spec.rb
@@ -3,35 +3,43 @@ require "spec_helper"
 module SocialNetworking
   describe ProfilePagesController, type: :controller do
     let(:group) { double("group", social_networking_profile_questions: []) }
-    let(:participant_status) { double("participant_status", :context= => "") }
     let(:participant) do
       instance_double(
         Participant,
-        active_group: group)
+        active_group: group,
+        id: 1)
     end
+    let(:profile) { instance_double(Profile, participant_id: 1, active: nil) }
     let(:initiator) { instance_double(Participant) }
+    let(:nudge) { instance_double(Nudge, initiator: initiator) }
 
     describe "GET show" do
       context "when the current participant is authenticated" do
         before do
           @routes = Engine.routes
-          allow(controller).to receive(:authenticate_participant!)
           allow(controller).to receive(:current_participant) { participant }
+
+          expect(controller).to receive(:store_nudge_initiators)
+          expect(controller).to receive(:set_member_profiles)
+          expect(controller).to receive(:load_feed_items)
         end
 
         context "when params contains profile id" do
-          after do
+          it "finds profile" do
+            expect(Profile).to receive(:find) { profile }
+
             get :show, id: 1
           end
+        end
 
-          context "current participant has been nudged" do
-            let(:nudge) { instance_double(Nudge, initiator: initiator) }
+        context "when viewing personal profile" do
+          it "finds or initializes a new profile" do
+            expect(Profile)
+              .to receive(:find_or_initialize_by) { profile }
+            expect(profile)
+              .to receive(:update_attributes).with(active: true)
 
-            it "displays the display name of the participant who nudged" do
-              allow(Nudge).to receive(:search) { [nudge] }
-
-              expect(initiator).to receive(:display_name)
-            end
+            get :show
           end
         end
       end

--- a/spec/controllers/social_networking/profiles_controller_spec.rb
+++ b/spec/controllers/social_networking/profiles_controller_spec.rb
@@ -3,26 +3,25 @@ require "spec_helper"
 module SocialNetworking
   describe ProfilesController, type: :controller do
     context "participant is authenticated" do
-      let(:participant) { double("participant") }
-      let(:profile) { double("profile") }
+      let(:participant) { instance_double("participant") }
+      let(:profile) { instance_double("profile") }
 
       before do
         @routes = Engine.routes
-        allow(controller).to receive(:current_participant) { participant }
-        allow(participant)
-          .to receive_message_chain(:social_networking_profile,
-                                    :find) { profile }
+
+        expect(controller).to receive(:current_participant) { participant }
+        expect(participant)
+          .to receive_message_chain(:social_networking_profile) { profile }
       end
 
       describe "PUT update" do
         context "update succeeds" do
           it "renders serialized profile" do
-            allow(profile).to receive_messages(update: true)
-
+            expect(profile).to receive_messages(update: true)
             expect(Serializers::ProfileSerializer)
               .to receive_message_chain(:new, :to_serialized)
 
-            put :update, icon_name: "purse", id: 1
+            put :update, id: 1
 
             assert_response 200
           end
@@ -32,8 +31,9 @@ module SocialNetworking
           let(:errors) { double("errors", full_messages: ["epic fail"]) }
 
           it "renders error message" do
-            allow(profile).to receive_messages(update: false, errors: errors)
-            put :update, icon_name: "purse", id: 1
+            expect(profile).to receive_messages(update: false, errors: errors)
+
+            put :update, id: 1
 
             assert_response 400
             expect(json["error"]).to eq ["epic fail"]

--- a/spec/controllers/social_networking/profiles_controller_spec.rb
+++ b/spec/controllers/social_networking/profiles_controller_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 module SocialNetworking
   describe ProfilesController, type: :controller do
     context "participant is authenticated" do
-      let(:participant) { instance_double("participant") }
-      let(:profile) { instance_double("profile") }
+      let(:participant) { instance_double(Participant) }
+      let(:profile) { instance_double(Profile) }
 
       before do
         @routes = Engine.routes
 
         expect(controller).to receive(:current_participant) { participant }
         expect(participant)
-          .to receive_message_chain(:social_networking_profile) { profile }
+          .to receive(:social_networking_profile) { profile }
       end
 
       describe "PUT update" do

--- a/spec/javascripts/social_networking/profile/profile-controller_spec.js
+++ b/spec/javascripts/social_networking/profile/profile-controller_spec.js
@@ -1,30 +1,45 @@
 describe('ProfileCtrl', function() {
   var controller,
+      mockAlertService,
       profileService,
       nudgeService,
       scope,
       q,
-      deferred;
+      deferred,
+      deferredNudgeCreate,
+      deferredProfileUpdate;
   
   beforeEach(function() {
     // load the module with the controller to test
     module('socialNetworking.controllers');
 
+    mockAlertService = {
+      addError: function() {}
+    };
     profileService = {
       getOne: function(profileId) {
-                deferred = q.defer();
-                return deferred.promise;
-              }
+        deferred = q.defer();
+        return deferred.promise;
+      },
+      update: function() {
+        deferredProfileUpdate = q.defer();
+        return deferredProfileUpdate.promise;
+      }
     };
-    nudgeService = {};
+    nudgeService = {
+      create: function() {
+        deferredNudgeCreate = q.defer();
+        return deferredNudgeCreate.promise;
+      }
+    };
   });
 
   beforeEach(inject(function($rootScope, $q, $controller) {
     scope = $rootScope;
     q = $q;
     controller = $controller('ProfileCtrl', {
+      alertService: mockAlertService,
       profileId: 1,
-      participantId: 123,
       Profiles: profileService,
       Nudges: nudgeService
     });
@@ -37,4 +52,29 @@ describe('ProfileCtrl', function() {
     expect(controller.id).toBe('1');
   });
 
+  it('displays alert message when nudge fails', function() {
+    spyOn(mockAlertService, 'addError');
+    controller.nudge();
+    deferredNudgeCreate.reject({ data: { error: '' } });
+    scope.$digest();
+
+    expect(mockAlertService.addError).toHaveBeenCalled();
+  });
+
+  it('displays alert message when profile icon is not found', function() {
+    spyOn(mockAlertService, 'addError');
+    deferred.reject({ data: { error: '' } });
+    scope.$digest();
+
+    expect(mockAlertService.addError).toHaveBeenCalled();
+  });
+
+  it('displays alert message when profile updating fails', function() {
+    spyOn(mockAlertService, 'addError');
+    controller.updateProfileIcon('');
+    deferredProfileUpdate.reject({ data: { error: '' } });
+    scope.$digest();
+
+    expect(mockAlertService.addError).toHaveBeenCalled();
+  });
 });

--- a/spec/javascripts/social_networking/services/AlertSpec.js
+++ b/spec/javascripts/social_networking/services/AlertSpec.js
@@ -22,6 +22,16 @@ describe('Alert', function() {
     });
   });
 
+  describe('#getAlerts', function() {
+    it('returns all alerts', function() {
+      expect(alertService.getAlerts()).toEqual([]);
+
+      alertService.alerts = ['foo']
+
+      expect(alertService.getAlerts()).toEqual(['foo']);
+    });
+  });
+
   describe('#removeAlert', function() {
     it('removes alert from array of alerts', function() {
       alertService.alerts = ['alert']

--- a/spec/javascripts/social_networking/services/AlertSpec.js
+++ b/spec/javascripts/social_networking/services/AlertSpec.js
@@ -1,0 +1,24 @@
+describe('Alert', function() {
+  var alertService;
+
+  beforeEach(module('socialNetworking.services'));
+
+  beforeEach(function() {
+    inject(function($injector) {
+      alertService = $injector.get('alertService');
+    });
+  });
+
+  describe('#addError', function() {
+    it('adds an error alert to the alerts array', function() {
+      expect(alertService.alerts).toEqual([]);
+
+      alertService.addError("Big Peanut");
+
+      expect(alertService.alerts).toEqual([{
+        cssClass: "alert-danger",
+        message: "Big Peanut"
+      }])
+    });
+  });
+});

--- a/spec/javascripts/social_networking/services/AlertSpec.js
+++ b/spec/javascripts/social_networking/services/AlertSpec.js
@@ -21,4 +21,13 @@ describe('Alert', function() {
       }])
     });
   });
+
+  describe('#removeAlert', function() {
+    it('removes alert from array of alerts', function() {
+      alertService.alerts = ['alert']
+      alertService.removeAlert('alert');
+
+      expect(alertService.alerts).toEqual([]);
+    });
+  });
 });

--- a/spec/models/social_networking/profile_spec.rb
+++ b/spec/models/social_networking/profile_spec.rb
@@ -32,5 +32,11 @@ module SocialNetworking
               ).to eq("Social Networking")
       end
     end
+
+    it "is shared after creation" do
+      expect do
+        Profile.create(participant: participant)
+      end.to change { SharedItem.count }.by(1)
+    end
   end
 end

--- a/spec/views/social_networking/profile_pages/show.html.erb_spec.rb
+++ b/spec/views/social_networking/profile_pages/show.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module SocialNetworking
+  RSpec.describe "social_networking/profile_pages/show.html.erb", type: :view do
+    it "displays all the nudges" do
+      allow(view)
+        .to receive(:current_participant)
+        .and_return(instance_double(Participant, id: 1))
+      assign(
+        :profile,
+        instance_double(
+          Profile,
+          icon_name: "",
+          id: 1,
+          participant_id: 1))
+      assign(:profile_icons, [])
+      assign(:nudging_display_names, [
+        "Old Man!", "Red Riding Hood"
+      ])
+
+      render
+
+      expect(rendered).to have_text "Old Man! and Red Riding Hood nudged you!"
+    end
+  end
+end


### PR DESCRIPTION
Fix Updating Profile Icon

* Only allow one `profile` to exist for each participants.
* Add alert for the user with errors if icon fails to update.
* Update controller conditions when creating profile.
* Find profile by calling profile on `current_participant`, not via params.

[#100582464]