### PR TITLE
Clear Navigation Context on Profile Page

### DIFF
--- a/app/controllers/social_networking/profile_pages_controller.rb
+++ b/app/controllers/social_networking/profile_pages_controller.rb
@@ -5,8 +5,8 @@ module SocialNetworking
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
     before_action :set_current_profile,
                   :set_profile_questions,
-                  :set_profile_icon_names
-
+                  :set_profile_icon_names,
+                  :set_navigation_status_context
     def index
     end
 
@@ -17,6 +17,10 @@ module SocialNetworking
     end
 
     private
+
+    def set_navigation_status_context
+      current_participant.navigation_status.context = nil
+    end
 
     def set_member_profiles
       return if current_participant.active_group.nil?

--- a/spec/controllers/social_networking/profile_pages_controller_spec.rb
+++ b/spec/controllers/social_networking/profile_pages_controller_spec.rb
@@ -12,12 +12,15 @@ module SocialNetworking
     let(:profile) { instance_double(Profile, participant_id: 1, active: nil) }
     let(:initiator) { instance_double(Participant) }
     let(:nudge) { instance_double(Nudge, initiator: initiator) }
+    let(:status) { double("status") }
 
     describe "GET show" do
       context "when the current participant is authenticated" do
         before do
           @routes = Engine.routes
+          allow(status).to receive(:context=)
           allow(controller).to receive(:current_participant) { participant }
+          allow(participant).to receive(:navigation_status) { status }
 
           expect(controller).to receive(:store_nudge_initiators)
           expect(controller).to receive(:set_member_profiles)
@@ -27,6 +30,13 @@ module SocialNetworking
         context "when params contains profile id" do
           it "finds profile" do
             expect(Profile).to receive(:find) { profile }
+
+            get :show, id: 1
+          end
+
+          it "sets the context of a participant's navigation status" do
+            expect(Profile).to receive(:find) { profile }
+            expect(status).to receive(:context=).with(nil)
 
             get :show, id: 1
           end

--- a/spec/dummy/app/models/participant.rb
+++ b/spec/dummy/app/models/participant.rb
@@ -1,6 +1,8 @@
 class Participant < ActiveRecord::Base
   include SocialNetworking::Concerns::Participant
 
+  attr_reader :navigation_status
+
   def active_membership_end_date
     Date.today.advance(weeks: 8)
   end


### PR DESCRIPTION
Clear Navigation Context on Profile Page

* Add `before_filter` to clear the navigation context.
* This fixes a bug that shows content in the header from previous page.

[#100847372]