### PR TITLE
Fix Like and Comment Controller Bug

### DIFF
--- a/app/controllers/social_networking/comments_controller.rb
+++ b/app/controllers/social_networking/comments_controller.rb
@@ -50,7 +50,7 @@ module SocialNetworking
       if @comment.item_type == "SocialNetworking::SharedItem"
         comment_item_participant_id =
           SharedItem.find(@comment.item_id).item_type.constantize
-          .find(@comment.item_id).participant_id
+          .find(@comment.item.item_id).participant_id
         @recipient = Participant.find(comment_item_participant_id)
       else
         @recipient = Participant

--- a/app/controllers/social_networking/likes_controller.rb
+++ b/app/controllers/social_networking/likes_controller.rb
@@ -36,7 +36,7 @@ module SocialNetworking
       if @like.item_type == "SocialNetworking::SharedItem"
         like_item_participant_id =
           SharedItem.find(@like.item_id).item_type.constantize
-          .find(@like.item_id).participant_id
+          .find(@like.item.item_id).participant_id
         @recipient = Participant.find(like_item_participant_id)
       else
         @recipient = Participant


### PR DESCRIPTION
Fix Like and Comment Controller Bug

* Update private method to find the `id` of the correct shared item.
* Add tests for liking and commenting on shareable items.

[Finished: #100766496]
[Finished: #103230832]