### PR TITLE
Move Common Sharing JS to SN

### DIFF
--- a/app/assets/javascripts/shared/new_shareable_form.js.erb
+++ b/app/assets/javascripts/shared/new_shareable_form.js.erb
@@ -1,0 +1,28 @@
+<% template = File.join(Rails.root, 'app/views/social_networking/shared/_sharing_fields.html') %>
+<% js_helper = Class.new.extend(ActionView::Helpers::JavaScriptHelper) %>
+
+;(function() {
+  function addSharingToNewShareableForm() {
+    'use strict';
+
+    var actionType,
+        displayName,
+        itemType,
+        placeholder, 
+        template;
+
+    placeholder = $('.new-shareable-form-after-form-groups');
+    actionType = placeholder.data('actionType');
+    itemType = placeholder.data('itemType');
+    template = '<%= js_helper.j Erubis::Eruby.new(File.read(template)).result %>';
+    displayName = itemType;
+    if (displayName) {
+      displayName = displayName.replace('_', ' ');
+    }
+    template = template.replace(/{{ ITEM_TYPE }}/g, itemType).replace(/{{ ITEM_TYPE_DISPLAY }}/g, displayName).replace(/{{ ACTION_TYPE }}/g, actionType);
+
+    placeholder.append(template);
+  };
+
+  $(document).on('page:ready page:change', addSharingToNewShareableForm);
+})();

--- a/spec/dummy/app/views/social_networking/shared/_sharing_fields.html
+++ b/spec/dummy/app/views/social_networking/shared/_sharing_fields.html
@@ -1,0 +1,12 @@
+<%# Form for testing. See social_networking/app/views/social_networking/shared/_sharing_fields.html for original %>
+<div class="form-group">
+  <label for="{{ ITEM_TYPE }}_shared_item">Share the content of this {{ ITEM_TYPE_DISPLAY }}?</label>
+  <label class="radio-inline">
+    <input type="radio" class="{{ ITEM_TYPE }}_shared_item_true" name="{{ ITEM_TYPE }}[shared_items_attributes][][is_public]" id="{{ ITEM_TYPE }}_shared_item_1" value="1" checked> Yes
+  </label>
+  <label class="radio-inline">
+    <input type="radio" name="{{ ITEM_TYPE }}[shared_items_attributes][][is_public]" id="{{ ITEM_TYPE }}_shared_item_2" value="0"> No
+  </label>
+</div>
+
+<input type="hidden" name="{{ ITEM_TYPE }}[shared_items_attributes][][action_type]" value="{{ ACTION_TYPE }}">

--- a/spec/javascripts/social_networking/new_shareable_form_spec.js
+++ b/spec/javascripts/social_networking/new_shareable_form_spec.js
@@ -1,0 +1,122 @@
+//= require jquery
+//= require shared/new_shareable_form
+
+'use strict';
+
+describe('addSharingToNewShareableForm', function() {
+  var ACTION_TYPE,
+      ITEM_TYPE;
+
+  ITEM_TYPE = 'activity';
+  ACTION_TYPE = 'planned';
+
+  function getFixture() {
+    return $('#jasmine_content');
+  };
+
+  function getPage() {
+    return getFixture()
+           .find('.new-shareable-form-after-form-groups');
+  };
+
+  function initListener(listener) {
+    $(document).trigger(listener);
+  };
+
+  function setPage() {
+    return getFixture()
+           .append('<span class="new-shareable-form-after-form-groups" data-item-type="' + ITEM_TYPE + '" data-action-type="' + ACTION_TYPE + '"></span>');
+  };
+
+  function setOtherPage() {
+    return getFixture();
+  };
+
+  afterEach(function() {
+    $('#jasmine_content').empty();
+  });
+
+  describe('when page does not have shareable field', function() {
+    describe('addSharingToNewShareableForm', function() {
+      describe('on page change', function() {
+        it('doesn\'t throw an error', function() {
+          setOtherPage();
+
+          expect(function() {
+            initListener('page:change')
+          }).not.toThrowError(TypeError);
+        });
+      });
+    });
+  });
+
+  describe('when page has shareable field', function() {
+    beforeEach(function() {
+      setPage();
+    });
+
+    describe('addSharingToNewShareableForm', function() {
+      describe('on page change', function() {
+        beforeEach(function() {
+          initListener('page:change');
+        });
+
+        it('formats label for attribute', function() {
+          expect(getPage().find('label[for=' + ITEM_TYPE + '_shared_item]').length)
+            .toEqual(1);
+        });
+
+        it('formats label content', function() {
+          expect(getPage().find('label[for=' + ITEM_TYPE + '_shared_item]').text())
+            .toMatch('Share the content of this ' + ITEM_TYPE);
+        });
+
+        it('formats "yes" radio input', function() {
+          expect(getPage().find('input#' + ITEM_TYPE + '_shared_item_1[value=1]').length)
+            .toEqual(1);
+        });
+
+        it('formats "no" radio input', function() {
+          expect(getPage().find('input#' + ITEM_TYPE + '_shared_item_2[value=0]').length)
+            .toEqual(1);
+        });
+
+        it('formats hidden inputs', function() {
+          expect(getPage().find('[value=planned]').length)
+            .toEqual(1);
+        });
+      });
+
+      describe('on page ready', function() {
+        beforeEach(function() {
+          initListener('page:ready');
+        });
+
+        it('formats label for attribute', function() {
+          expect(getPage().find('label[for=' + ITEM_TYPE + '_shared_item]').length)
+            .toEqual(1);
+        });
+
+        it('formats label content', function() {
+          expect(getPage().find('label[for=' + ITEM_TYPE + '_shared_item]').text())
+            .toMatch('Share the content of this ' + ITEM_TYPE);
+        });
+
+        it('formats "yes" radio input', function() {
+          expect(getPage().find('input#' + ITEM_TYPE + '_shared_item_1[value=1]').length)
+            .toEqual(1);
+        });
+
+        it('formats "no" radio input', function() {
+          expect(getPage().find('input#' + ITEM_TYPE + '_shared_item_2[value=0]').length)
+            .toEqual(1);
+        });
+
+        it('formats hidden inputs', function() {
+          expect(getPage().find('[value=' + ACTION_TYPE + ']').length)
+            .toEqual(1);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
* Move `addSharingToNewShareableForm` from host apps.
* Add dummy view used in specs.
* Move specs to SN testing suite.

[Finished: #103441490]