### PR TITLE
Update Views to Hide Admin Timestamp

### DIFF
--- a/app/assets/javascripts/social_networking/directives.js
+++ b/app/assets/javascripts/social_networking/directives.js
@@ -5,7 +5,9 @@
   function profileStatus() {
     return {
       template: '<h2>{{ profile.username }}</h2>' +
-                '<h3>Last seen: {{ profile.latestAction | timeFromNow }}</h3>'
+                '<h3 ng-class="profile.isAdmin ? \'invisible\' : \'\'">' +
+                  'Last seen: {{ profile.latestAction | timeFromNow }}' +
+                '</h3>'
     };
   }
 

--- a/app/views/social_networking/homes/show.html.erb
+++ b/app/views/social_networking/homes/show.html.erb
@@ -13,7 +13,9 @@
           </div>
 
           <div class="profile-border profile-last-seen">
-            <p>Last seen: {{ profile.latestAction | timeFromNow }}</p>
+            <p ng-class="profile.isAdmin ? 'invisible' : ''">
+              Last seen: {{ profile.latestAction | timeFromNow }}
+            </p>
           </div>
         </div>
       </div>

--- a/app/views/social_networking/profile_pages/index.html.erb
+++ b/app/views/social_networking/profile_pages/index.html.erb
@@ -8,7 +8,9 @@
           {{ profile.username }}
         </a>
       </p>
-      <p>Last seen: {{ profile.latestAction | timeFromNow }}</p>
+      <p ng-class="profile.isAdmin ? 'invisible' : ''">
+        Last seen: {{ profile.latestAction | timeFromNow }}
+      </p>
     </div>
     <dl>
       <dt ng-repeat-start="r in profile.responses">{{ r.question }}</dt>

--- a/app/views/social_networking/profile_pages/show.html.erb
+++ b/app/views/social_networking/profile_pages/show.html.erb
@@ -44,7 +44,9 @@
     </div>
 
     <div class="profiles-last-online profile-box-border">
-      <h3>Last seen: {{ profile.profile.latestAction | timeFromNow }}</h3>
+      <h3 ng-class="profile.profile.isAdmin ? 'invisible' : ''">
+        Last seen: {{ profile.profile.latestAction | timeFromNow }}
+      </h3>
     </div>
 
     <% if current_participant.id != @profile.participant_id %>


### PR DESCRIPTION
* Profile views do not display timestamp if participant is admin
* Add bootstrap `invisible` CSS class that makes text hidden.

[Finished: #104565788]