### PR TITLE
Add Not Default Profile Migration

### DIFF
--- a/db/migrate/20151211204425_change_column_default_social_networking_profiles_active_to_false.rb
+++ b/db/migrate/20151211204425_change_column_default_social_networking_profiles_active_to_false.rb
@@ -1,0 +1,9 @@
+class ChangeColumnDefaultSocialNetworkingProfilesActiveToFalse < ActiveRecord::Migration
+  def change
+    change_column_default :social_networking_profiles, :active, false
+    SocialNetworking::Profile.where(active: nil).each do |p|
+      p.update!(active: false)
+    end
+    change_column_null :social_networking_profiles, :active, false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150327185919) do
+ActiveRecord::Schema.define(version: 20151211204425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,11 +106,11 @@ ActiveRecord::Schema.define(version: 20150327185919) do
   end
 
   create_table "social_networking_profiles", force: :cascade do |t|
-    t.integer  "participant_id", null: false
+    t.integer  "participant_id",                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "icon_name"
-    t.boolean  "active"
+    t.boolean  "active",         default: false, null: false
   end
 
   create_table "social_networking_shared_items", force: :cascade do |t|


### PR DESCRIPTION
* Add migration to update social_networking `profile` attribute.
* Add a default to `profile` attribute.
* Update all existing `profile` attributes that are `nil` to `true`.
* No longer allow the `profile` attribute to be null.

[#99322588]